### PR TITLE
Add HasKeyParam trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ All notable changes to `datum` will be documented in this file
 
 ## 0.7.1 - 2021-02-09
 - make Sfneal\Queries\Traits\HasKeyParam trait for AbstractQuery extensions that require a $modelKey param
+- add improved type hinting to test Filters & Queries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,7 @@ All notable changes to `datum` will be documented in this file
 ## 0.7.0 - 2021-02-09
 - cut AbstractStaticQuery as it provides no additional functionality compared to AbstractQuery (and use cases result in inconsistent method params & returns)
 - add abstract execute() method to AbstractQuery that will force child classes to conform
+
+
+## 0.7.1 - 2021-02-09
+- make Sfneal\Queries\Traits\HasKeyParam trait for AbstractQuery extensions that require a $modelKey param

--- a/src/Queries/Traits/HasKeyParam.php
+++ b/src/Queries/Traits/HasKeyParam.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Queries\Traits;
-
 
 trait HasKeyParam
 {

--- a/src/Queries/Traits/HasKeyParam.php
+++ b/src/Queries/Traits/HasKeyParam.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace Sfneal\Queries\Traits;
+
+
+trait HasKeyParam
+{
+    /**
+     * @var int|array|null
+     */
+    private $modelKey;
+
+    /**
+     * @var array
+     */
+    private $params;
+
+    /**
+     * ArticleQuery constructor.
+     *
+     * @param int|array|null $modelKey
+     * @param mixed ...$params
+     */
+    public function __construct($modelKey = null, ...$params)
+    {
+        $this->modelKey = $modelKey;
+        $this->params = $params;
+    }
+}

--- a/tests/Filters/CityFilter.php
+++ b/tests/Filters/CityFilter.php
@@ -14,7 +14,7 @@ class CityFilter implements FilterInterface
      * @param mixed $value
      * @return Builder $query
      */
-    public function apply(Builder $query, $value)
+    public function apply(Builder $query, $value): Builder
     {
         $query->whereIn('city', (array) $value);
 

--- a/tests/Filters/FranklinFilter.php
+++ b/tests/Filters/FranklinFilter.php
@@ -14,7 +14,7 @@ class FranklinFilter implements FilterInterface
      * @param mixed $value
      * @return Builder $query
      */
-    public function apply(Builder $query, $value)
+    public function apply(Builder $query, $value): Builder
     {
         $query
             ->where('city', '=', 'Franklin')

--- a/tests/Filters/GoatFilter.php
+++ b/tests/Filters/GoatFilter.php
@@ -14,7 +14,7 @@ class GoatFilter implements FilterInterface
      * @param mixed $value
      * @return Builder $query
      */
-    public function apply(Builder $query, $value)
+    public function apply(Builder $query, $value): Builder
     {
         $query->orWhere(function (Builder $builder) {
             $builder

--- a/tests/Filters/MassFilter.php
+++ b/tests/Filters/MassFilter.php
@@ -14,7 +14,7 @@ class MassFilter implements FilterInterface
      * @param mixed $value
      * @return Builder $query
      */
-    public function apply(Builder $query, $value)
+    public function apply(Builder $query, $value): Builder
     {
         $query->where('state', '=', 'MA');
 

--- a/tests/Filters/NameLastFilter.php
+++ b/tests/Filters/NameLastFilter.php
@@ -14,7 +14,7 @@ class NameLastFilter implements FilterInterface
      * @param mixed $value
      * @return Builder $query
      */
-    public function apply(Builder $query, $value)
+    public function apply(Builder $query, $value): Builder
     {
         $query->whereIn('name_last', (array) $value);
 

--- a/tests/Filters/NealFilter.php
+++ b/tests/Filters/NealFilter.php
@@ -14,7 +14,7 @@ class NealFilter implements FilterInterface
      * @param mixed $value
      * @return Builder $query
      */
-    public function apply(Builder $query, $value)
+    public function apply(Builder $query, $value): Builder
     {
         $query->where('name_last', '=', 'Neal');
 

--- a/tests/HasKeyParamTest.php
+++ b/tests/HasKeyParamTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Sfneal\Datum\Tests;
+
+use Sfneal\Datum\Tests\Models\People;
+use Sfneal\Datum\Tests\Queries\PeopleQuery;
+
+class HasKeyParamTest extends TestCase
+{
+    /**
+     * @var int
+     */
+    private $id;
+
+    /**
+     * Setup the test environment.
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Retrieve a random model that is not the first or last
+        $this->id = People::query()
+            ->get()
+            ->shuffle()
+            ->first()
+            ->person_id;
+    }
+
+    public function test_has_key_param()
+    {
+        $expected = People::query()->find($this->id);
+        $model = (new PeopleQuery($this->id))->execute()->get()->first();
+
+        $this->assertEquals($expected, $model);
+    }
+}

--- a/tests/Queries/PeopleQuery.php
+++ b/tests/Queries/PeopleQuery.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Sfneal\Datum\Tests\Queries;
-
 
 use Illuminate\Database\Eloquent\Builder;
 use Sfneal\Datum\Tests\Models\People;

--- a/tests/Queries/PeopleQuery.php
+++ b/tests/Queries/PeopleQuery.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Sfneal\Datum\Tests\Queries;
+
+
+use Illuminate\Database\Eloquent\Builder;
+use Sfneal\Datum\Tests\Models\People;
+use Sfneal\Queries\AbstractQuery;
+use Sfneal\Queries\Traits\HasKeyParam;
+
+class PeopleQuery extends AbstractQuery
+{
+    use HasKeyParam;
+
+    /**
+     * Execute a DB query.
+     *
+     * @return Builder
+     */
+    public function execute(): Builder
+    {
+        return People::query()
+            ->where('person_id', '=', $this->modelKey);
+    }
+}

--- a/tests/Queries/PeopleQueryWithFilter.php
+++ b/tests/Queries/PeopleQueryWithFilter.php
@@ -29,7 +29,7 @@ class PeopleQueryWithFilter extends AbstractQueryWithFilter
      *
      * @return Builder
      */
-    public function execute()
+    public function execute(): Builder
     {
         // Initialize query
         $query = People::query();

--- a/tests/Queries/PeopleQueryWithFilters.php
+++ b/tests/Queries/PeopleQueryWithFilters.php
@@ -27,7 +27,7 @@ class PeopleQueryWithFilters extends AbstractQueryWithFilters
      *
      * @return Builder
      */
-    public function execute()
+    public function execute(): Builder
     {
         // Initialize query
         $query = People::query();


### PR DESCRIPTION
- make Sfneal\Queries\Traits\HasKeyParam trait for AbstractQuery extensions that require a $modelKey param
- add improved type hinting to test Filters & Queries