### PR TITLE
BUMP min sfneal/caching version to 1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,8 @@ All notable changes to `datum` will be documented in this file
 ## 0.7.1 - 2021-02-09
 - make Sfneal\Queries\Traits\HasKeyParam trait for AbstractQuery extensions that require a $modelKey param
 - add improved type hinting to test Filters & Queries
+
+
+## 0.7.2 - 2021-02-10
+- bump min sfneal/caching version to 1.2 to make use of isCached() method provided by the Cacheable trait
+- optimize return type hinting in NextOrPreviousModel::execute() method

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=7.3",
         "illuminate/database": ">=8.2",
         "illuminate/http": "*",
-        "sfneal/caching": ">=1.0",
+        "sfneal/caching": ">=1.2",
         "sfneal/models": ">=1.0",
         "sfneal/string-helpers": ">=1.0"
     },

--- a/src/Queries/CacheModelQuery.php
+++ b/src/Queries/CacheModelQuery.php
@@ -4,7 +4,6 @@ namespace Sfneal\Queries;
 
 use Illuminate\Database\Eloquent\Model;
 use Sfneal\Caching\Traits\Cacheable;
-use Sfneal\Helpers\Redis\RedisCache;
 
 class CacheModelQuery extends AbstractQuery
 {
@@ -80,15 +79,5 @@ class CacheModelQuery extends AbstractQuery
         $key = "{$table}:{$this->model_key}";
 
         return $key.(is_null($this->attribute) ? '' : ":{$this->attribute}");
-    }
-
-    /**
-     * Determine if the query is currently cached.
-     *
-     * @return bool
-     */
-    public function isCached(): bool
-    {
-        return RedisCache::exists($this->cacheKey());
     }
 }

--- a/src/Queries/NextOrPreviousModelQuery.php
+++ b/src/Queries/NextOrPreviousModelQuery.php
@@ -50,7 +50,7 @@ class NextOrPreviousModelQuery extends AbstractQuery
      *
      * @return Model|null
      */
-    public function execute()
+    public function execute(): ?Model
     {
         $query = $this->model::query();
 


### PR DESCRIPTION
- bump min sfneal/caching version to 1.2 to make use of isCached() method provided by the Cacheable trait
- optimize return type hinting in NextOrPreviousModel::execute() method