### PR TITLE
sfneal/models v2.0 & sfneal/caching v1.3 upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,3 +96,9 @@ All notable changes to `datum` will be documented in this file
 
 ## 1.1.0 - 2021-04-06
 - fix sfneal packages version constraints to ^1.0
+
+
+## 1.2.0 - 2021-04-07
+- bump sfneal/models min version to v2.0
+- refactor use of Eloquent `Model` to Sfneal `AbstractModel`
+- bump sfneal/caching min version to v1.3 to avoid conflicts with sfneal/actions v2.0

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/database": ">=8.2",
         "illuminate/http": "*",
         "sfneal/caching": "^1.2",
-        "sfneal/models": "^1.0",
+        "sfneal/models": "^2.0",
         "sfneal/string-helpers": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=7.3",
         "illuminate/database": ">=8.2",
         "illuminate/http": "*",
-        "sfneal/caching": "^1.2",
+        "sfneal/caching": "^1.3",
         "sfneal/models": "^2.0",
         "sfneal/string-helpers": "^1.0"
     },

--- a/src/Queries/CacheModelQuery.php
+++ b/src/Queries/CacheModelQuery.php
@@ -4,7 +4,7 @@ namespace Sfneal\Queries;
 
 use Illuminate\Database\Eloquent\Builder;
 use Sfneal\Caching\Traits\Cacheable;
-use Sfneal\Models\AbstractModel;
+use Sfneal\Models\Model;
 
 class CacheModelQuery extends Query
 {
@@ -16,7 +16,7 @@ class CacheModelQuery extends Query
     /**
      * Target Model.
      *
-     * @var AbstractModel
+     * @var Model
      */
     protected $model;
 
@@ -61,7 +61,7 @@ class CacheModelQuery extends Query
     /**
      * Retrieve a Service's title.
      *
-     * @return AbstractModel|string
+     * @return Model|string
      */
     public function execute()
     {

--- a/src/Queries/CacheModelQuery.php
+++ b/src/Queries/CacheModelQuery.php
@@ -3,8 +3,8 @@
 namespace Sfneal\Queries;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 use Sfneal\Caching\Traits\Cacheable;
+use Sfneal\Models\AbstractModel;
 
 class CacheModelQuery extends Query
 {
@@ -16,7 +16,7 @@ class CacheModelQuery extends Query
     /**
      * Target Model.
      *
-     * @var Model
+     * @var AbstractModel
      */
     protected $model;
 
@@ -61,7 +61,7 @@ class CacheModelQuery extends Query
     /**
      * Retrieve a Service's title.
      *
-     * @return Model|string
+     * @return AbstractModel|string
      */
     public function execute()
     {
@@ -86,7 +86,7 @@ class CacheModelQuery extends Query
      */
     public function cacheKey(): string
     {
-        $table = (new $this->model)->getTable();
+        $table = $this->model::getTableName();
         $key = "{$table}:{$this->model_key}";
 
         return $key.(is_null($this->attribute) ? '' : ":{$this->attribute}");

--- a/src/Queries/NextOrPreviousModelQuery.php
+++ b/src/Queries/NextOrPreviousModelQuery.php
@@ -3,7 +3,7 @@
 namespace Sfneal\Queries;
 
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Sfneal\Caching\Traits\Cacheable;
 use Sfneal\Models\AbstractModel;
 
@@ -59,10 +59,11 @@ class NextOrPreviousModelQuery extends Query
     /**
      * Retrieve the 'next' or 'previous' Model.
      *
-     * @return Model|null
+     * @return EloquentModel|null
      */
-    public function execute(): ?Model
+    public function execute(): ?EloquentModel
     {
+        // todo: improve return type hinting
         $query = $this->model::query();
 
         // Next Model

--- a/src/Queries/NextOrPreviousModelQuery.php
+++ b/src/Queries/NextOrPreviousModelQuery.php
@@ -5,7 +5,7 @@ namespace Sfneal\Queries;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 use Sfneal\Caching\Traits\Cacheable;
-use Sfneal\Models\AbstractModel;
+use Sfneal\Models\Model;
 
 class NextOrPreviousModelQuery extends Query
 {
@@ -22,7 +22,7 @@ class NextOrPreviousModelQuery extends Query
     private $cache_key_string;
 
     /**
-     * @var AbstractModel|string
+     * @var Model|string
      */
     private $model;
 
@@ -34,7 +34,7 @@ class NextOrPreviousModelQuery extends Query
     /**
      * NextOrPreviousModelQuery constructor.
      *
-     * @param AbstractModel|string $model
+     * @param Model|string $model
      * @param int $model_id
      * @param bool $next
      */

--- a/tests/Models/People.php
+++ b/tests/Models/People.php
@@ -4,9 +4,9 @@ namespace Sfneal\Datum\Tests\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Sfneal\Datum\Tests\Factories\PeopleFactory;
-use Sfneal\Models\AbstractModel;
+use Sfneal\Models\Model;
 
-class People extends AbstractModel
+class People extends Model
 {
     use HasFactory;
 

--- a/tests/Queries/CachePeopleEmailQuery.php
+++ b/tests/Queries/CachePeopleEmailQuery.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Datum\Tests\Queries;
 
-use Illuminate\Database\Eloquent\Model;
 use Sfneal\Datum\Tests\Models\People;
 use Sfneal\Datum\Tests\Queries\Traits\PeopleBuilder;
 use Sfneal\Queries\CacheModelQuery;
@@ -14,7 +13,7 @@ class CachePeopleEmailQuery extends CacheModelQuery
     /**
      * Target Model.
      *
-     * @var Model
+     * @var People
      */
     protected $model = People::class;
 

--- a/tests/Queries/CachePeopleQuery.php
+++ b/tests/Queries/CachePeopleQuery.php
@@ -2,9 +2,9 @@
 
 namespace Sfneal\Datum\Tests\Queries;
 
-use Illuminate\Database\Eloquent\Model;
 use Sfneal\Datum\Tests\Models\People;
 use Sfneal\Datum\Tests\Queries\Traits\PeopleBuilder;
+use Sfneal\Models\AbstractModel;
 use Sfneal\Queries\CacheModelQuery;
 
 class CachePeopleQuery extends CacheModelQuery
@@ -14,7 +14,7 @@ class CachePeopleQuery extends CacheModelQuery
     /**
      * Target Model.
      *
-     * @var Model
+     * @var AbstractModel
      */
     protected $model = People::class;
 }

--- a/tests/Queries/CachePeopleQuery.php
+++ b/tests/Queries/CachePeopleQuery.php
@@ -4,7 +4,7 @@ namespace Sfneal\Datum\Tests\Queries;
 
 use Sfneal\Datum\Tests\Models\People;
 use Sfneal\Datum\Tests\Queries\Traits\PeopleBuilder;
-use Sfneal\Models\AbstractModel;
+use Sfneal\Models\Model;
 use Sfneal\Queries\CacheModelQuery;
 
 class CachePeopleQuery extends CacheModelQuery
@@ -14,7 +14,7 @@ class CachePeopleQuery extends CacheModelQuery
     /**
      * Target Model.
      *
-     * @var AbstractModel
+     * @var Model
      */
     protected $model = People::class;
 }


### PR DESCRIPTION
- bump sfneal/models min version to v2.0
- refactor use of Eloquent `Model` to Sfneal `AbstractModel`
- bump sfneal/caching min version to v1.3 to avoid conflicts with sfneal/actions v2.0