### PR TITLE
Add explicit sfneal/address dev requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,3 +128,7 @@ All notable changes to `datum` will be documented in this file
 
 ## 1.5.1 - 2021-06-17
 - optimize test suite by refactoring into 'Feature' & 'Unit' directories
+ 
+ 
+## 1.5.2 - 2021-08-18
+- add explicit sfneal/address dev requirement because it was removed as a dependency of sfneal/models

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "orchestra/testbench": ">=6.7",
         "phpunit/phpunit": ">=7.5.20",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.6"
+        "sfneal/mock-models": ">=0.6",
+        "sfneal/address": "^1.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- add explicit sfneal/address dev requirement because it was removed as a dependency of sfneal/models