### PR TITLE
sfneal/caching v2.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,3 +132,8 @@ All notable changes to `datum` will be documented in this file
  
 ## 1.5.2 - 2021-08-18
 - add explicit sfneal/address dev requirement because it was removed as a dependency of sfneal/models
+
+
+## 1.5.3 - 2021-08-31
+- add support for sfneal/caching v2.0
+- fix use of '#' cache key id suffix delimiter with ':'

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": ">=7.3",
         "illuminate/database": ">=8.2",
         "illuminate/http": "*",
-        "sfneal/caching": "^1.3",
+        "sfneal/caching": "^1.3|^2.0",
         "sfneal/models": "^2.2",
         "sfneal/string-helpers": "^1.0"
     },

--- a/src/Queries/NextOrPreviousModelQuery.php
+++ b/src/Queries/NextOrPreviousModelQuery.php
@@ -110,6 +110,6 @@ class NextOrPreviousModelQuery extends Query
      */
     public function cacheKey(): string
     {
-        return $this->model::getTableName().":{$this->cache_key_string}:#{$this->model_id}";
+        return $this->model::getTableName().":{$this->cache_key_string}:{$this->model_id}";
     }
 }


### PR DESCRIPTION
- add support for sfneal/caching v2.0
- fix use of '#' cache key id suffix delimiter with ':'