### PR TITLE
Dependency Upgrades

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
+        "php": "^7.3|^8.0",
         "illuminate/database": ">=8.2",
         "illuminate/http": "*",
-        "sfneal/caching": "^1.3|^2.0",
+        "sfneal/caching": "^1.3|^2.0|^3.0",
         "sfneal/models": "^2.2",
         "sfneal/string-helpers": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
     },
     "require-dev": {
         "josiasmontag/laravel-redis-mock": ">=1.2.6",
-        "orchestra/testbench": ">=6.7",
-        "phpunit/phpunit": ">=7.5.20",
+        "orchestra/testbench": "^6.24.1|^7.0",
+        "phpunit/phpunit": "^9.3",
         "scrutinizer/ocular": "^1.8",
         "sfneal/mock-models": ">=0.6",
         "sfneal/address": "^1.2"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,11 +4,11 @@ namespace Sfneal\Datum\Tests;
 
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
 use Orchestra\Testbench\TestCase as OrchestraTestCase;
 use Sfneal\Address\Models\Address;
 use Sfneal\Address\Providers\AddressServiceProvider;
 use Sfneal\Helpers\Redis\Providers\RedisHelpersServiceProvider;
-use Sfneal\Helpers\Redis\RedisCache;
 use Sfneal\Testing\Models\People;
 use Sfneal\Testing\Providers\MockModelsServiceProvider;
 
@@ -74,7 +74,7 @@ class TestCase extends OrchestraTestCase
      */
     protected function tearDown(): void
     {
-        RedisCache::flush();
+        Cache::flush();
         parent::tearDown();
     }
 


### PR DESCRIPTION
- bump php & sfneal/caching version constraints
- fix issue with depreciated call to `Cache::flush()` in `TestCase`